### PR TITLE
Face API Controller Creation and Permit Updates

### DIFF
--- a/src/main/java/com/open/spring/mvc/person/FaceApiController.java
+++ b/src/main/java/com/open/spring/mvc/person/FaceApiController.java
@@ -1,0 +1,90 @@
+package com.open.spring.mvc.person;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@RestController
+@RequestMapping("/api/face")
+public class FaceApiController {
+    private static final Logger logger = LoggerFactory.getLogger(FaceApiController.class);
+
+    @Autowired
+    private PersonJpaRepository repository;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter
+    @Setter
+    public static class FaceDto {
+        private String faceData;
+    }
+
+    /**
+     * Registration for authenticated users to save their face data.
+     */
+    @PostMapping("/register")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Object> registerFace(Authentication authentication, @RequestBody FaceDto faceDto) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        String uid = userDetails.getUsername();
+
+        Person person = repository.findByUid(uid);
+        if (person == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        if (faceDto.getFaceData() == null || faceDto.getFaceData().isEmpty()) {
+            return new ResponseEntity<>("Face data is required", HttpStatus.BAD_REQUEST);
+        }
+
+        person.setFaceData(faceDto.getFaceData());
+        repository.save(person);
+
+        logger.info("Face data registered for user: {}", uid);
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "Face data registered successfully");
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    /**
+     * Restricted endpoint for teachers and admins to get all face data for matching.
+     */
+    @GetMapping("/faces")
+    @PreAuthorize("hasAnyAuthority('ROLE_TEACHER', 'ROLE_ADMIN')")
+    public ResponseEntity<List<Map<String, String>>> getFaces() {
+        List<Person> people = repository.findByFaceDataIsNotNull();
+        List<Map<String, String>> faces = new ArrayList<>();
+        for (Person person : people) {
+            Map<String, String> face = new HashMap<>();
+            face.put("uid", person.getUid());
+            face.put("name", person.getName());
+            face.put("faceData", person.getFaceData());
+            faces.add(face);
+        }
+        return new ResponseEntity<>(faces, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/open/spring/mvc/person/PersonApiController.java
+++ b/src/main/java/com/open/spring/mvc/person/PersonApiController.java
@@ -118,30 +118,8 @@ public class PersonApiController {
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
-    /**
-     * Retrieves all Person entities that have face data registered.
-     * Returns a list of maps containing 'uid' and 'faceData'.
-     * 
-     * @return A ResponseEntity containing a list of maps with uid and faceData.
-     */
-    @GetMapping("/person/faces")
-    // Public for bathroom-pass face matcher (self-service). Security is via token/cookie in other workflows.
-    public ResponseEntity<List<Map<String, String>>> getPersonFaces() {
-        List<Person> people = repository.findByFaceDataIsNotNull();
-        List<Map<String, String>> faces = new ArrayList<>();
-        for (Person person : people) {
-            Map<String, String> face = new HashMap<>();
-            face.put("uid", person.getUid());
-            String name = person.getName();
-            if (name == null || name.isEmpty()) {
-                name = person.getUid();
-            }
-            face.put("name", name);
-            face.put("faceData", person.getFaceData());
-            faces.add(face);
-        }
-        return new ResponseEntity<>(faces, HttpStatus.OK);
-    }
+    // Removed: GET /api/person/faces has been moved to FaceApiController (/api/face/faces).
+    // Access is now restricted to ROLE_TEACHER and ROLE_ADMIN only.
 
 
     /**
@@ -182,14 +160,6 @@ public class PersonApiController {
             boolean uidChangeRequested = personDto.getUid() != null
                     && !personDto.getUid().equals(existingPerson.getUid());
             
-            // Log faceData receipt for debugging
-            if (personDto.getFaceData() != null) {
-                logger.info("UPDATE received faceData for user: {}. Length: {}", email, personDto.getFaceData().length());
-            }
-
-            boolean faceDataChanged = personDto.getFaceData() != null
-                    && !personDto.getFaceData().equals(existingPerson.getFaceData());
-
             if (!isAdmin && uidChangeRequested) {
                 logger.warn("AUDIT profile_update_blocked actor={} reason=uid_change_not_allowed",
                         existingPerson.getUid());
@@ -241,11 +211,6 @@ public class PersonApiController {
             if (kasmChanged) {
                 existingPerson.setKasmServerNeeded(personDto.getKasmServerNeeded());
                 changedFields.append("kasmServerNeeded,");
-            }
-            if (faceDataChanged) {
-                existingPerson.setFaceData(personDto.getFaceData());
-                changedFields.append("faceData,");
-                logger.info("Persisting faceData for user: {}. Length: {}", email, existingPerson.getFaceData().length());
             }
             // Save the updated person back to the repository
             Person updatedPerson = repository.save(existingPerson);
@@ -318,7 +283,7 @@ public class PersonApiController {
         private String name;
         private String pfp;
         private Boolean kasmServerNeeded;
-        private String faceData;
+        // faceData removed: use POST /api/face/register (FaceApiController) instead.
     }
 
     /**
@@ -724,10 +689,6 @@ public class PersonApiController {
             if (sidChanged) {
                 existingPerson.setSid(personDto.getSid());
                 changedFields.append("sid,");
-            }
-            if (personDto.getFaceData() != null) {
-                existingPerson.setFaceData(personDto.getFaceData());
-                changedFields.append("faceData,");
             }
             // Save the updated person back to the repository
             repository.save(existingPerson);

--- a/src/main/java/com/open/spring/security/SecurityConfig.java
+++ b/src/main/java/com/open/spring/security/SecurityConfig.java
@@ -101,14 +101,18 @@ public class SecurityConfig {
                         // ← GIST CREATION ENDPOINTS - PUBLIC (NO AUTH)
                         .requestMatchers(HttpMethod.POST, "/api/grades/create-gist").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/grades/create-gist/").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/person/faces").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/person/identify").permitAll()
                         // ← MAKE DEBUGGER - PUBLIC (NO AUTH)
                         .requestMatchers("/api/make/**").permitAll()
                         // Admin-only endpoints, beware of DELETE operations and impact to cascading relational data 
                         .requestMatchers(HttpMethod.DELETE, "/api/person/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/person/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/person/uid/**").permitAll()
+                        // Face biometric data:
+                        //   GET /faces  - teacher/admin only (scanner feed)
+                        //   POST /register - any authenticated user (self-service face enrollment)
+                        .requestMatchers(HttpMethod.GET, "/api/face/faces").hasAnyAuthority("ROLE_TEACHER", "ROLE_ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/face/register").hasAnyAuthority("ROLE_USER", "ROLE_STUDENT", "ROLE_TEACHER", "ROLE_ADMIN")
+                        .requestMatchers("/api/face/**").hasAnyAuthority("ROLE_TEACHER", "ROLE_ADMIN")
 
                         // All other /api/person/** and /api/people/** operations handled by default rule
                         // ======================================================
@@ -226,6 +230,10 @@ public class SecurityConfig {
         policy.put("DELETE /api/person/**", "ROLE_ADMIN");
         policy.put("PUT /api/person/**", "ROLE_ADMIN");
         policy.put("GET /api/person/uid/**", "permitAll");
+        // Face biometric endpoints
+        policy.put("GET /api/face/faces", "ROLE_TEACHER|ROLE_ADMIN");
+        policy.put("POST /api/face/register", "ROLE_USER|ROLE_STUDENT|ROLE_TEACHER|ROLE_ADMIN");
+        policy.put("/api/face/**", "ROLE_TEACHER|ROLE_ADMIN");
         policy.put("POST /api/assignment-submissions/upload", "ROLE_USER|ROLE_ADMIN|ROLE_TEACHER|ROLE_STUDENT");
         policy.put("/api/exports/**", "ROLE_ADMIN");
         policy.put("/api/imports/**", "ROLE_ADMIN");


### PR DESCRIPTION
Added new Face API controller which has permits for only teachers and admins to use the scanner, but all authenticated users can register. Permits are updated in security config. Removed all face api endpoints from person controller to avoid public endpoints and security issues.