### PR TITLE
Fixing security for bathroom pass regarding visible face data to authenticated non-admin users

### DIFF
--- a/src/main/java/com/open/spring/mvc/person/Person.java
+++ b/src/main/java/com/open/spring/mvc/person/Person.java
@@ -131,6 +131,7 @@ public class Person extends Submitter implements Comparable<Person> {
 
     /** Facial data for recognition (base64 or embedding) */
     @Column(columnDefinition = "text")
+    @JsonIgnore
     private String faceData;
 
     /**


### PR DESCRIPTION
Addressed Lucas's concern: I was able to obtain access to face data again yesterday. The endpoint /api/people is open when authenticated (even with a normal student role) and contains base64 faceData . I'm not sure if this is contained within the threat model, so I think there's a way to simply hide faceData specifically from that query while still leaving that endpoint open.

I have resolved the issue by specifically hiding the faceData field from standard JSON serialization. Since the /api/people and similar general-purpose endpoints simply serialize the Person entity automatically, adding a @JsonIgnore annotation to faceData prevents it from ever being exposed via these endpoints.