### PR TITLE
Adding public endpoint for N@TM face registers

### DIFF
--- a/src/main/java/com/open/spring/mvc/person/FaceApiController.java
+++ b/src/main/java/com/open/spring/mvc/person/FaceApiController.java
@@ -39,6 +39,45 @@ public class FaceApiController {
         private String faceData;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter
+    @Setter
+    public static class PublicFaceDto {
+        private String sid;
+        private String uid;
+        private String faceData;
+    }
+
+    /**
+     * Public unauthenticated registration to save face data by student ID or GitHub ID.
+     */
+    @PostMapping("/register/public")
+    public ResponseEntity<Object> registerPublicFace(@RequestBody PublicFaceDto publicFaceDto) {
+        if (publicFaceDto.getFaceData() == null || publicFaceDto.getFaceData().isEmpty()) {
+            return new ResponseEntity<>("Face data is required", HttpStatus.BAD_REQUEST);
+        }
+
+        Person person = null;
+        if (publicFaceDto.getSid() != null && !publicFaceDto.getSid().isBlank()) {
+            person = repository.findBySid(publicFaceDto.getSid());
+        }
+        if (person == null && publicFaceDto.getUid() != null && !publicFaceDto.getUid().isBlank()) {
+            person = repository.findByUid(publicFaceDto.getUid());
+        }
+
+        if (person == null) {
+            return new ResponseEntity<>("Student not found", HttpStatus.NOT_FOUND);
+        }
+
+        person.setFaceData(publicFaceDto.getFaceData());
+        repository.save(person);
+
+        logger.info("Public face data registered for user: {}", person.getUid());
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "Face data registered successfully");
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
     /**
      * Registration for authenticated users to save their face data.
      */

--- a/src/main/java/com/open/spring/security/SecurityConfig.java
+++ b/src/main/java/com/open/spring/security/SecurityConfig.java
@@ -110,6 +110,7 @@ public class SecurityConfig {
                         // Face biometric data:
                         //   GET /faces  - teacher/admin only (scanner feed)
                         //   POST /register - any authenticated user (self-service face enrollment)
+                        .requestMatchers(HttpMethod.POST, "/api/face/register/public", "/api/face/register/public/").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/face/faces").hasAnyAuthority("ROLE_TEACHER", "ROLE_ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/face/register").hasAnyAuthority("ROLE_USER", "ROLE_STUDENT", "ROLE_TEACHER", "ROLE_ADMIN")
                         .requestMatchers("/api/face/**").hasAnyAuthority("ROLE_TEACHER", "ROLE_ADMIN")
@@ -233,6 +234,7 @@ public class SecurityConfig {
         policy.put("PUT /api/person/**", "ROLE_ADMIN");
         policy.put("GET /api/person/uid/**", "permitAll");
         // Face biometric endpoints
+        policy.put("POST /api/face/register/public", "permitAll");
         policy.put("GET /api/face/faces", "ROLE_TEACHER|ROLE_ADMIN");
         policy.put("POST /api/face/register", "ROLE_USER|ROLE_STUDENT|ROLE_TEACHER|ROLE_ADMIN");
         policy.put("/api/face/**", "ROLE_TEACHER|ROLE_ADMIN");


### PR DESCRIPTION
For N@TM, the face scan will be used to register future students for the next year's hall pass. To avoid logging in every single time, the public endpoint for resigerting a face is used to map the kid and face data to spring backend.